### PR TITLE
fix: allow FlagGetter to return Flags not just their values

### DIFF
--- a/command.go
+++ b/command.go
@@ -337,8 +337,10 @@ func (c *Command) execute(ctx *Context) error {
 				if f == nil {
 					return fmt.Errorf("missing flag: %v", flagStr[0])
 				}
-				if value == "" && f.Type() != flags.BoolFlagType {
-					if len(ctx.args) > 1 {
+				if value == "" {
+					if f.Type() == flags.BoolFlagType {
+						value = "true"
+					} else if len(ctx.args) > 1 {
 						if next := ctx.args[1]; next[0] != '-' {
 							value = next
 							ctx.args = ctx.args[1:]

--- a/examples/flags/main.go
+++ b/examples/flags/main.go
@@ -20,6 +20,9 @@ var rootCmd = &gommand.Command{
 		if err != nil {
 			return err
 		}
+		if !ctx.Flags().Flag("insensitive").IsSet() {
+			fmt.Println("insensitive used default value")
+		}
 		s, err := ctx.Flags().LookupStringSlice("strings")
 		if err != nil {
 			return err

--- a/flags/bool.go
+++ b/flags/bool.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type boolFlag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue bool
 	value    bool
@@ -14,57 +14,57 @@ type boolFlag struct {
 func (f *boolFlag) Type() FlagType { return BoolFlagType }
 
 func (f *boolFlag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *boolFlag) Set(s string) error {
-    v, err := strconv.ParseBool(s)
-    if err != nil {
-        return err
-    }
-    f.value = v
-    f.set = true
-    return nil
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	f.value = v
+	f.set = true
+	return nil
 }
 
 func BoolFlag(name string, value bool, usage string) Flag {
-    return &boolFlag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &boolFlag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func BoolFlagS(name string, shorthand rune, value bool, usage string) Flag {
-    return &boolFlag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &boolFlag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Bool(name string, value bool, usage string) {
-    fs.addFlag(BoolFlag(name, value, usage))
+	fs.addFlag(BoolFlag(name, value, usage))
 }
 
 func (fs *FlagSet) BoolS(name string, shorthand rune, value bool, usage string) {
-    fs.addFlag(BoolFlagS(name, shorthand, value, usage))
+	fs.addFlag(BoolFlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) boolVal(name string) (bool, error) {
-    f, err := fs.flag(name, BoolFlagType)
-    if err != nil {
-        return false, err
-    }
-    return f.Value().(bool), nil
+	f, err := fs.flag(name, BoolFlagType)
+	if err != nil {
+		return false, err
+	}
+	return f.Value().(bool), nil
 }
 
 func (g FlagGetter) LookupBool(name string) (bool, error) {
-    return g.fs.boolVal(name)
+	return g.fs.boolVal(name)
 }
 
 func (g FlagGetter) Bool(name string) bool {
-    v, _ := g.LookupBool(name)
-    return v
+	v, _ := g.LookupBool(name)
+	return v
 }

--- a/flags/duration.go
+++ b/flags/duration.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "time"
+	"time"
 )
 
 type durationFlag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue time.Duration
 	value    time.Duration
@@ -14,57 +14,57 @@ type durationFlag struct {
 func (f *durationFlag) Type() FlagType { return DurationFlagType }
 
 func (f *durationFlag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *durationFlag) Set(s string) error {
-    v, err := time.ParseDuration(s)
-    if err != nil {
-        return err
-    }
-    f.value = v
-    f.set = true
-    return nil
+	v, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	f.value = v
+	f.set = true
+	return nil
 }
 
 func DurationFlag(name string, value time.Duration, usage string) Flag {
-    return &durationFlag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &durationFlag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func DurationFlagS(name string, shorthand rune, value time.Duration, usage string) Flag {
-    return &durationFlag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &durationFlag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Duration(name string, value time.Duration, usage string) {
-    fs.addFlag(DurationFlag(name, value, usage))
+	fs.addFlag(DurationFlag(name, value, usage))
 }
 
 func (fs *FlagSet) DurationS(name string, shorthand rune, value time.Duration, usage string) {
-    fs.addFlag(DurationFlagS(name, shorthand, value, usage))
+	fs.addFlag(DurationFlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) durationVal(name string) (time.Duration, error) {
-    f, err := fs.flag(name, DurationFlagType)
-    if err != nil {
-        return time.Duration(0), err
-    }
-    return f.Value().(time.Duration), nil
+	f, err := fs.flag(name, DurationFlagType)
+	if err != nil {
+		return time.Duration(0), err
+	}
+	return f.Value().(time.Duration), nil
 }
 
 func (g FlagGetter) LookupDuration(name string) (time.Duration, error) {
-    return g.fs.durationVal(name)
+	return g.fs.durationVal(name)
 }
 
 func (g FlagGetter) Duration(name string) time.Duration {
-    v, _ := g.LookupDuration(name)
-    return v
+	v, _ := g.LookupDuration(name)
+	return v
 }

--- a/flags/flag_getter.go
+++ b/flags/flag_getter.go
@@ -1,9 +1,13 @@
 package flags
 
+func NewFlagGetter(fs *FlagSet) *FlagGetter {
+	return &FlagGetter{fs: fs}
+}
+
 type FlagGetter struct {
 	fs *FlagSet
 }
 
-func NewFlagGetter(fs *FlagSet) *FlagGetter {
-	return &FlagGetter{fs: fs}
+func (g FlagGetter) Flag(name string) Flag {
+	return g.fs.FromName(name)
 }

--- a/flags/flagger/flag.gotmpl
+++ b/flags/flagger/flag.gotmpl
@@ -1,12 +1,12 @@
 package flags
 
 {{ if .Imports -}}import ({{ range .Imports }}
-    "{{ . }}"{{ end }}
+	"{{ . }}"{{ end }}
 )
 
 {{ end -}}
 type {{ .Name }}Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue {{ .Type }}
 	value    {{ .Type }}
@@ -15,61 +15,61 @@ type {{ .Name }}Flag struct {
 func (f *{{ .Name }}Flag) Type() FlagType { return {{ pascal .Name }}FlagType }
 
 func (f *{{ .Name }}Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *{{ .Name }}Flag) Set(s string) error {
-    {{- if .ParseFunc }}
-    v, err := {{ .ParseFunc }}
-    if err != nil {
-        return err
-    }
-    f.value = {{ if .ConvertParsed }}{{ .Type }}(v){{ else }}v{{end}}
-    {{ else }}
-    f.value = s
-    {{ end -}}
-    f.set = true
-    return nil
+	{{- if .ParseFunc }}
+	v, err := {{ .ParseFunc }}
+	if err != nil {
+		return err
+	}
+	f.value = {{ if .ConvertParsed }}{{ .Type }}(v){{ else }}v{{end}}
+	{{ else }}
+	f.value = s
+	{{ end -}}
+	f.set = true
+	return nil
 }
 
 func {{ pascal .Name }}Flag(name string, value {{ .Type }}, usage string) Flag {
-    return &{{ .Name }}Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &{{ .Name }}Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func {{ pascal .Name }}FlagS(name string, shorthand rune, value {{ .Type }}, usage string) Flag {
-    return &{{ .Name }}Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &{{ .Name }}Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) {{ pascal .Name }}(name string, value {{ .Type }}, usage string) {
-    fs.addFlag({{ pascal .Name }}Flag(name, value, usage))
+	fs.addFlag({{ pascal .Name }}Flag(name, value, usage))
 }
 
 func (fs *FlagSet) {{ pascal .Name }}S(name string, shorthand rune, value {{ .Type }}, usage string) {
-    fs.addFlag({{ pascal .Name }}FlagS(name, shorthand, value, usage))
+	fs.addFlag({{ pascal .Name }}FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) {{ .Name }}Val(name string) ({{ .Type }}, error) {
-    f, err := fs.flag(name, {{ pascal .Name }}FlagType)
-    if err != nil {
-        return {{ .Default }}, err
-    }
-    return f.Value().({{ .Type }}), nil
+	f, err := fs.flag(name, {{ pascal .Name }}FlagType)
+	if err != nil {
+		return {{ .Default }}, err
+	}
+	return f.Value().({{ .Type }}), nil
 }
 
 func (g FlagGetter) Lookup{{ pascal .Name }}(name string) ({{ .Type }}, error) {
-    return g.fs.{{ .Name }}Val(name)
+	return g.fs.{{ .Name }}Val(name)
 }
 
 func (g FlagGetter) {{ pascal .Name }}(name string) {{ .Type }} {
-    v, _ := g.Lookup{{ pascal .Name }}(name)
-    return v
+	v, _ := g.Lookup{{ pascal .Name }}(name)
+	return v
 }

--- a/flags/float32.go
+++ b/flags/float32.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type float32Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue float32
 	value    float32
@@ -14,57 +14,57 @@ type float32Flag struct {
 func (f *float32Flag) Type() FlagType { return Float32FlagType }
 
 func (f *float32Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *float32Flag) Set(s string) error {
-    v, err := strconv.ParseFloat(s, 32)
-    if err != nil {
-        return err
-    }
-    f.value = float32(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseFloat(s, 32)
+	if err != nil {
+		return err
+	}
+	f.value = float32(v)
+	f.set = true
+	return nil
 }
 
 func Float32Flag(name string, value float32, usage string) Flag {
-    return &float32Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &float32Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Float32FlagS(name string, shorthand rune, value float32, usage string) Flag {
-    return &float32Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &float32Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Float32(name string, value float32, usage string) {
-    fs.addFlag(Float32Flag(name, value, usage))
+	fs.addFlag(Float32Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Float32S(name string, shorthand rune, value float32, usage string) {
-    fs.addFlag(Float32FlagS(name, shorthand, value, usage))
+	fs.addFlag(Float32FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) float32Val(name string) (float32, error) {
-    f, err := fs.flag(name, Float32FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(float32), nil
+	f, err := fs.flag(name, Float32FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(float32), nil
 }
 
 func (g FlagGetter) LookupFloat32(name string) (float32, error) {
-    return g.fs.float32Val(name)
+	return g.fs.float32Val(name)
 }
 
 func (g FlagGetter) Float32(name string) float32 {
-    v, _ := g.LookupFloat32(name)
-    return v
+	v, _ := g.LookupFloat32(name)
+	return v
 }

--- a/flags/float64.go
+++ b/flags/float64.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type float64Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue float64
 	value    float64
@@ -14,57 +14,57 @@ type float64Flag struct {
 func (f *float64Flag) Type() FlagType { return Float64FlagType }
 
 func (f *float64Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *float64Flag) Set(s string) error {
-    v, err := strconv.ParseFloat(s, 64)
-    if err != nil {
-        return err
-    }
-    f.value = v
-    f.set = true
-    return nil
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return err
+	}
+	f.value = v
+	f.set = true
+	return nil
 }
 
 func Float64Flag(name string, value float64, usage string) Flag {
-    return &float64Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &float64Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Float64FlagS(name string, shorthand rune, value float64, usage string) Flag {
-    return &float64Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &float64Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Float64(name string, value float64, usage string) {
-    fs.addFlag(Float64Flag(name, value, usage))
+	fs.addFlag(Float64Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Float64S(name string, shorthand rune, value float64, usage string) {
-    fs.addFlag(Float64FlagS(name, shorthand, value, usage))
+	fs.addFlag(Float64FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) float64Val(name string) (float64, error) {
-    f, err := fs.flag(name, Float64FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(float64), nil
+	f, err := fs.flag(name, Float64FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(float64), nil
 }
 
 func (g FlagGetter) LookupFloat64(name string) (float64, error) {
-    return g.fs.float64Val(name)
+	return g.fs.float64Val(name)
 }
 
 func (g FlagGetter) Float64(name string) float64 {
-    v, _ := g.LookupFloat64(name)
-    return v
+	v, _ := g.LookupFloat64(name)
+	return v
 }

--- a/flags/int.go
+++ b/flags/int.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type intFlag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue int
 	value    int
@@ -14,57 +14,57 @@ type intFlag struct {
 func (f *intFlag) Type() FlagType { return IntFlagType }
 
 func (f *intFlag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *intFlag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 64)
-    if err != nil {
-        return err
-    }
-    f.value = int(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+	f.value = int(v)
+	f.set = true
+	return nil
 }
 
 func IntFlag(name string, value int, usage string) Flag {
-    return &intFlag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &intFlag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func IntFlagS(name string, shorthand rune, value int, usage string) Flag {
-    return &intFlag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &intFlag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Int(name string, value int, usage string) {
-    fs.addFlag(IntFlag(name, value, usage))
+	fs.addFlag(IntFlag(name, value, usage))
 }
 
 func (fs *FlagSet) IntS(name string, shorthand rune, value int, usage string) {
-    fs.addFlag(IntFlagS(name, shorthand, value, usage))
+	fs.addFlag(IntFlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) intVal(name string) (int, error) {
-    f, err := fs.flag(name, IntFlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(int), nil
+	f, err := fs.flag(name, IntFlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(int), nil
 }
 
 func (g FlagGetter) LookupInt(name string) (int, error) {
-    return g.fs.intVal(name)
+	return g.fs.intVal(name)
 }
 
 func (g FlagGetter) Int(name string) int {
-    v, _ := g.LookupInt(name)
-    return v
+	v, _ := g.LookupInt(name)
+	return v
 }

--- a/flags/int16.go
+++ b/flags/int16.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type int16Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue int16
 	value    int16
@@ -14,57 +14,57 @@ type int16Flag struct {
 func (f *int16Flag) Type() FlagType { return Int16FlagType }
 
 func (f *int16Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *int16Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 16)
-    if err != nil {
-        return err
-    }
-    f.value = int16(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 16)
+	if err != nil {
+		return err
+	}
+	f.value = int16(v)
+	f.set = true
+	return nil
 }
 
 func Int16Flag(name string, value int16, usage string) Flag {
-    return &int16Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &int16Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Int16FlagS(name string, shorthand rune, value int16, usage string) Flag {
-    return &int16Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &int16Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Int16(name string, value int16, usage string) {
-    fs.addFlag(Int16Flag(name, value, usage))
+	fs.addFlag(Int16Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Int16S(name string, shorthand rune, value int16, usage string) {
-    fs.addFlag(Int16FlagS(name, shorthand, value, usage))
+	fs.addFlag(Int16FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) int16Val(name string) (int16, error) {
-    f, err := fs.flag(name, Int16FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(int16), nil
+	f, err := fs.flag(name, Int16FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(int16), nil
 }
 
 func (g FlagGetter) LookupInt16(name string) (int16, error) {
-    return g.fs.int16Val(name)
+	return g.fs.int16Val(name)
 }
 
 func (g FlagGetter) Int16(name string) int16 {
-    v, _ := g.LookupInt16(name)
-    return v
+	v, _ := g.LookupInt16(name)
+	return v
 }

--- a/flags/int32.go
+++ b/flags/int32.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type int32Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue int32
 	value    int32
@@ -14,57 +14,57 @@ type int32Flag struct {
 func (f *int32Flag) Type() FlagType { return Int32FlagType }
 
 func (f *int32Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *int32Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 32)
-    if err != nil {
-        return err
-    }
-    f.value = int32(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 32)
+	if err != nil {
+		return err
+	}
+	f.value = int32(v)
+	f.set = true
+	return nil
 }
 
 func Int32Flag(name string, value int32, usage string) Flag {
-    return &int32Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &int32Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Int32FlagS(name string, shorthand rune, value int32, usage string) Flag {
-    return &int32Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &int32Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Int32(name string, value int32, usage string) {
-    fs.addFlag(Int32Flag(name, value, usage))
+	fs.addFlag(Int32Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Int32S(name string, shorthand rune, value int32, usage string) {
-    fs.addFlag(Int32FlagS(name, shorthand, value, usage))
+	fs.addFlag(Int32FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) int32Val(name string) (int32, error) {
-    f, err := fs.flag(name, Int32FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(int32), nil
+	f, err := fs.flag(name, Int32FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(int32), nil
 }
 
 func (g FlagGetter) LookupInt32(name string) (int32, error) {
-    return g.fs.int32Val(name)
+	return g.fs.int32Val(name)
 }
 
 func (g FlagGetter) Int32(name string) int32 {
-    v, _ := g.LookupInt32(name)
-    return v
+	v, _ := g.LookupInt32(name)
+	return v
 }

--- a/flags/int64.go
+++ b/flags/int64.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type int64Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue int64
 	value    int64
@@ -14,57 +14,57 @@ type int64Flag struct {
 func (f *int64Flag) Type() FlagType { return Int64FlagType }
 
 func (f *int64Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *int64Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 64)
-    if err != nil {
-        return err
-    }
-    f.value = v
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+	f.value = v
+	f.set = true
+	return nil
 }
 
 func Int64Flag(name string, value int64, usage string) Flag {
-    return &int64Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &int64Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Int64FlagS(name string, shorthand rune, value int64, usage string) Flag {
-    return &int64Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &int64Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Int64(name string, value int64, usage string) {
-    fs.addFlag(Int64Flag(name, value, usage))
+	fs.addFlag(Int64Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Int64S(name string, shorthand rune, value int64, usage string) {
-    fs.addFlag(Int64FlagS(name, shorthand, value, usage))
+	fs.addFlag(Int64FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) int64Val(name string) (int64, error) {
-    f, err := fs.flag(name, Int64FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(int64), nil
+	f, err := fs.flag(name, Int64FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(int64), nil
 }
 
 func (g FlagGetter) LookupInt64(name string) (int64, error) {
-    return g.fs.int64Val(name)
+	return g.fs.int64Val(name)
 }
 
 func (g FlagGetter) Int64(name string) int64 {
-    v, _ := g.LookupInt64(name)
-    return v
+	v, _ := g.LookupInt64(name)
+	return v
 }

--- a/flags/int8.go
+++ b/flags/int8.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type int8Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue int8
 	value    int8
@@ -14,57 +14,57 @@ type int8Flag struct {
 func (f *int8Flag) Type() FlagType { return Int8FlagType }
 
 func (f *int8Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *int8Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 8)
-    if err != nil {
-        return err
-    }
-    f.value = int8(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 8)
+	if err != nil {
+		return err
+	}
+	f.value = int8(v)
+	f.set = true
+	return nil
 }
 
 func Int8Flag(name string, value int8, usage string) Flag {
-    return &int8Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &int8Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Int8FlagS(name string, shorthand rune, value int8, usage string) Flag {
-    return &int8Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &int8Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Int8(name string, value int8, usage string) {
-    fs.addFlag(Int8Flag(name, value, usage))
+	fs.addFlag(Int8Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Int8S(name string, shorthand rune, value int8, usage string) {
-    fs.addFlag(Int8FlagS(name, shorthand, value, usage))
+	fs.addFlag(Int8FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) int8Val(name string) (int8, error) {
-    f, err := fs.flag(name, Int8FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(int8), nil
+	f, err := fs.flag(name, Int8FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(int8), nil
 }
 
 func (g FlagGetter) LookupInt8(name string) (int8, error) {
-    return g.fs.int8Val(name)
+	return g.fs.int8Val(name)
 }
 
 func (g FlagGetter) Int8(name string) int8 {
-    v, _ := g.LookupInt8(name)
-    return v
+	v, _ := g.LookupInt8(name)
+	return v
 }

--- a/flags/string.go
+++ b/flags/string.go
@@ -1,7 +1,7 @@
 package flags
 
 type stringFlag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue string
 	value    string
@@ -10,53 +10,53 @@ type stringFlag struct {
 func (f *stringFlag) Type() FlagType { return StringFlagType }
 
 func (f *stringFlag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *stringFlag) Set(s string) error {
-    f.value = s
-    f.set = true
-    return nil
+	f.value = s
+	f.set = true
+	return nil
 }
 
 func StringFlag(name string, value string, usage string) Flag {
-    return &stringFlag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &stringFlag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func StringFlagS(name string, shorthand rune, value string, usage string) Flag {
-    return &stringFlag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &stringFlag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) String(name string, value string, usage string) {
-    fs.addFlag(StringFlag(name, value, usage))
+	fs.addFlag(StringFlag(name, value, usage))
 }
 
 func (fs *FlagSet) StringS(name string, shorthand rune, value string, usage string) {
-    fs.addFlag(StringFlagS(name, shorthand, value, usage))
+	fs.addFlag(StringFlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) stringVal(name string) (string, error) {
-    f, err := fs.flag(name, StringFlagType)
-    if err != nil {
-        return "", err
-    }
-    return f.Value().(string), nil
+	f, err := fs.flag(name, StringFlagType)
+	if err != nil {
+		return "", err
+	}
+	return f.Value().(string), nil
 }
 
 func (g FlagGetter) LookupString(name string) (string, error) {
-    return g.fs.stringVal(name)
+	return g.fs.stringVal(name)
 }
 
 func (g FlagGetter) String(name string) string {
-    v, _ := g.LookupString(name)
-    return v
+	v, _ := g.LookupString(name)
+	return v
 }

--- a/flags/uint.go
+++ b/flags/uint.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type uintFlag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue uint
 	value    uint
@@ -14,57 +14,57 @@ type uintFlag struct {
 func (f *uintFlag) Type() FlagType { return UintFlagType }
 
 func (f *uintFlag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *uintFlag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 64)
-    if err != nil {
-        return err
-    }
-    f.value = uint(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+	f.value = uint(v)
+	f.set = true
+	return nil
 }
 
 func UintFlag(name string, value uint, usage string) Flag {
-    return &uintFlag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &uintFlag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func UintFlagS(name string, shorthand rune, value uint, usage string) Flag {
-    return &uintFlag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &uintFlag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Uint(name string, value uint, usage string) {
-    fs.addFlag(UintFlag(name, value, usage))
+	fs.addFlag(UintFlag(name, value, usage))
 }
 
 func (fs *FlagSet) UintS(name string, shorthand rune, value uint, usage string) {
-    fs.addFlag(UintFlagS(name, shorthand, value, usage))
+	fs.addFlag(UintFlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) uintVal(name string) (uint, error) {
-    f, err := fs.flag(name, UintFlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(uint), nil
+	f, err := fs.flag(name, UintFlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(uint), nil
 }
 
 func (g FlagGetter) LookupUint(name string) (uint, error) {
-    return g.fs.uintVal(name)
+	return g.fs.uintVal(name)
 }
 
 func (g FlagGetter) Uint(name string) uint {
-    v, _ := g.LookupUint(name)
-    return v
+	v, _ := g.LookupUint(name)
+	return v
 }

--- a/flags/uint16.go
+++ b/flags/uint16.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type uint16Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue uint16
 	value    uint16
@@ -14,57 +14,57 @@ type uint16Flag struct {
 func (f *uint16Flag) Type() FlagType { return Uint16FlagType }
 
 func (f *uint16Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *uint16Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 16)
-    if err != nil {
-        return err
-    }
-    f.value = uint16(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 16)
+	if err != nil {
+		return err
+	}
+	f.value = uint16(v)
+	f.set = true
+	return nil
 }
 
 func Uint16Flag(name string, value uint16, usage string) Flag {
-    return &uint16Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &uint16Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Uint16FlagS(name string, shorthand rune, value uint16, usage string) Flag {
-    return &uint16Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &uint16Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Uint16(name string, value uint16, usage string) {
-    fs.addFlag(Uint16Flag(name, value, usage))
+	fs.addFlag(Uint16Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Uint16S(name string, shorthand rune, value uint16, usage string) {
-    fs.addFlag(Uint16FlagS(name, shorthand, value, usage))
+	fs.addFlag(Uint16FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) uint16Val(name string) (uint16, error) {
-    f, err := fs.flag(name, Uint16FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(uint16), nil
+	f, err := fs.flag(name, Uint16FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(uint16), nil
 }
 
 func (g FlagGetter) LookupUint16(name string) (uint16, error) {
-    return g.fs.uint16Val(name)
+	return g.fs.uint16Val(name)
 }
 
 func (g FlagGetter) Uint16(name string) uint16 {
-    v, _ := g.LookupUint16(name)
-    return v
+	v, _ := g.LookupUint16(name)
+	return v
 }

--- a/flags/uint32.go
+++ b/flags/uint32.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type uint32Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue uint32
 	value    uint32
@@ -14,57 +14,57 @@ type uint32Flag struct {
 func (f *uint32Flag) Type() FlagType { return Uint32FlagType }
 
 func (f *uint32Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *uint32Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 32)
-    if err != nil {
-        return err
-    }
-    f.value = uint32(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 32)
+	if err != nil {
+		return err
+	}
+	f.value = uint32(v)
+	f.set = true
+	return nil
 }
 
 func Uint32Flag(name string, value uint32, usage string) Flag {
-    return &uint32Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &uint32Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Uint32FlagS(name string, shorthand rune, value uint32, usage string) Flag {
-    return &uint32Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &uint32Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Uint32(name string, value uint32, usage string) {
-    fs.addFlag(Uint32Flag(name, value, usage))
+	fs.addFlag(Uint32Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Uint32S(name string, shorthand rune, value uint32, usage string) {
-    fs.addFlag(Uint32FlagS(name, shorthand, value, usage))
+	fs.addFlag(Uint32FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) uint32Val(name string) (uint32, error) {
-    f, err := fs.flag(name, Uint32FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(uint32), nil
+	f, err := fs.flag(name, Uint32FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(uint32), nil
 }
 
 func (g FlagGetter) LookupUint32(name string) (uint32, error) {
-    return g.fs.uint32Val(name)
+	return g.fs.uint32Val(name)
 }
 
 func (g FlagGetter) Uint32(name string) uint32 {
-    v, _ := g.LookupUint32(name)
-    return v
+	v, _ := g.LookupUint32(name)
+	return v
 }

--- a/flags/uint64.go
+++ b/flags/uint64.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type uint64Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue uint64
 	value    uint64
@@ -14,57 +14,57 @@ type uint64Flag struct {
 func (f *uint64Flag) Type() FlagType { return Uint64FlagType }
 
 func (f *uint64Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *uint64Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 64)
-    if err != nil {
-        return err
-    }
-    f.value = uint64(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+	f.value = uint64(v)
+	f.set = true
+	return nil
 }
 
 func Uint64Flag(name string, value uint64, usage string) Flag {
-    return &uint64Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &uint64Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Uint64FlagS(name string, shorthand rune, value uint64, usage string) Flag {
-    return &uint64Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &uint64Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Uint64(name string, value uint64, usage string) {
-    fs.addFlag(Uint64Flag(name, value, usage))
+	fs.addFlag(Uint64Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Uint64S(name string, shorthand rune, value uint64, usage string) {
-    fs.addFlag(Uint64FlagS(name, shorthand, value, usage))
+	fs.addFlag(Uint64FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) uint64Val(name string) (uint64, error) {
-    f, err := fs.flag(name, Uint64FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(uint64), nil
+	f, err := fs.flag(name, Uint64FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(uint64), nil
 }
 
 func (g FlagGetter) LookupUint64(name string) (uint64, error) {
-    return g.fs.uint64Val(name)
+	return g.fs.uint64Val(name)
 }
 
 func (g FlagGetter) Uint64(name string) uint64 {
-    v, _ := g.LookupUint64(name)
-    return v
+	v, _ := g.LookupUint64(name)
+	return v
 }

--- a/flags/uint8.go
+++ b/flags/uint8.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-    "strconv"
+	"strconv"
 )
 
 type uint8Flag struct {
-    *baseFlag
+	*baseFlag
 
 	defValue uint8
 	value    uint8
@@ -14,57 +14,57 @@ type uint8Flag struct {
 func (f *uint8Flag) Type() FlagType { return Uint8FlagType }
 
 func (f *uint8Flag) Value() any {
-    if f.IsSet() {
-        return f.value
-    }
-    return f.defValue
+	if f.IsSet() {
+		return f.value
+	}
+	return f.defValue
 }
 
 func (f *uint8Flag) Set(s string) error {
-    v, err := strconv.ParseInt(s, 0, 8)
-    if err != nil {
-        return err
-    }
-    f.value = uint8(v)
-    f.set = true
-    return nil
+	v, err := strconv.ParseInt(s, 0, 8)
+	if err != nil {
+		return err
+	}
+	f.value = uint8(v)
+	f.set = true
+	return nil
 }
 
 func Uint8Flag(name string, value uint8, usage string) Flag {
-    return &uint8Flag{
-        baseFlag: &baseFlag{name: name, usage: usage},
-        defValue: value,
-    }
+	return &uint8Flag{
+		baseFlag: &baseFlag{name: name, usage: usage},
+		defValue: value,
+	}
 }
 
 func Uint8FlagS(name string, shorthand rune, value uint8, usage string) Flag {
-    return &uint8Flag{
-        baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
-        defValue: value,
-    }
+	return &uint8Flag{
+		baseFlag: &baseFlag{name: name, short: shorthand, usage: usage},
+		defValue: value,
+	}
 }
 
 func (fs *FlagSet) Uint8(name string, value uint8, usage string) {
-    fs.addFlag(Uint8Flag(name, value, usage))
+	fs.addFlag(Uint8Flag(name, value, usage))
 }
 
 func (fs *FlagSet) Uint8S(name string, shorthand rune, value uint8, usage string) {
-    fs.addFlag(Uint8FlagS(name, shorthand, value, usage))
+	fs.addFlag(Uint8FlagS(name, shorthand, value, usage))
 }
 
 func (fs *FlagSet) uint8Val(name string) (uint8, error) {
-    f, err := fs.flag(name, Uint8FlagType)
-    if err != nil {
-        return 0, err
-    }
-    return f.Value().(uint8), nil
+	f, err := fs.flag(name, Uint8FlagType)
+	if err != nil {
+		return 0, err
+	}
+	return f.Value().(uint8), nil
 }
 
 func (g FlagGetter) LookupUint8(name string) (uint8, error) {
-    return g.fs.uint8Val(name)
+	return g.fs.uint8Val(name)
 }
 
 func (g FlagGetter) Uint8(name string) uint8 {
-    v, _ := g.LookupUint8(name)
-    return v
+	v, _ := g.LookupUint8(name)
+	return v
 }


### PR DESCRIPTION
flag getter now has a `.Flag` method to return the `Flag` belonging to the provided name. 
This is useful for telling whether the value for the flag was the default, or explicitly set to the same value as the default.