### PR TITLE
fix: append persistent items to context

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,11 +8,25 @@ import (
 
 type Context struct {
 	context.Context
-	args       []string
-	preRuns    []func(*Context) error
-	postRuns   []func(*Context) error
-	deferPost  bool
+	cmd          *Command
+	args         []string
+	preRuns      []func(*Context) error
+	postRuns     []func(*Context) error
+	deferPost    bool
+	silenceHelp  bool
+	silenceError bool
+
+	persistentFlags *flags.FlagSet
+
 	flagGetter *flags.FlagGetter
+}
+
+func (c *Context) addPersistentFlags(fs *flags.FlagSet) {
+	if c.persistentFlags == nil {
+		c.persistentFlags = fs
+	} else {
+		c.persistentFlags.AddFlagSet(fs)
+	}
 }
 
 func (c *Context) Args() []string {

--- a/examples/subcommands/main.go
+++ b/examples/subcommands/main.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/jimmykodes/gommand"
+	"github.com/jimmykodes/gommand/flags"
 )
 
 var (
@@ -13,6 +14,11 @@ var (
 		Name:         "math",
 		Description:  "a collection of math commands",
 		SilenceError: true,
+		PersistentFlags: []flags.Flag{
+			flags.StringFlag("host", "", "host address"),
+			flags.IntFlag("port", 8080, "port number"),
+			flags.BoolFlagS("serve", 's', false, "serve something to the host and port"),
+		},
 	}
 	sumCmd = &gommand.Command{
 		Name:         "sum",

--- a/flags/flag.go
+++ b/flags/flag.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -69,24 +68,24 @@ type Flag interface {
 	SetEnvPrefix(string)
 }
 
-func Stringer(flag Flag, nameLen int) string {
+func Stringer(flag Flag, nameLen int, hasShort bool) string {
 	var sb strings.Builder
-
-	_, _ = fmt.Fprint(&sb, "  ")
-	if flag.Short() > 0 {
-		_, _ = fmt.Fprint(&sb, "-", string(byte(flag.Short())), ", ")
-	} else {
-		_, _ = fmt.Fprint(&sb, "    ")
+	sb.WriteString("  ")
+	if hasShort {
+		if flag.Short() > 0 {
+			sb.WriteString("-")
+			sb.WriteRune(flag.Short())
+			sb.WriteString(", ")
+		} else {
+			sb.WriteString("    ")
+		}
 	}
 
-	_, _ = fmt.Fprint(
-		&sb,
-		"--",
-		flag.Name(),
-		strings.Repeat(" ", nameLen-len(flag.Name())),
-		"  ",
-		flag.Usage(),
-	)
+	sb.WriteString("--")
+	sb.WriteString(flag.Name())
+	sb.WriteString(strings.Repeat(" ", nameLen-len(flag.Name())))
+	sb.WriteString("  ")
+	sb.WriteString(flag.Usage())
 	return sb.String()
 }
 

--- a/flags/flagset.go
+++ b/flags/flagset.go
@@ -47,18 +47,24 @@ func (fs *FlagSet) AddFlag(f Flag) {
 }
 
 func (fs *FlagSet) Repr() string {
-	names := make([]string, 0, len(fs.flags))
-	maxLen := 0
+	var (
+		names    = make([]string, 0, len(fs.flags))
+		maxLen   = 0
+		hasShort = false
+	)
 	for n, flag := range fs.flags {
 		names = append(names, n)
 		if l := len(flag.Name()); l > maxLen {
 			maxLen = l
 		}
+		if flag.Short() != 0 {
+			hasShort = true
+		}
 	}
 	sort.Strings(names)
 	strs := make([]string, len(names))
 	for i, name := range names {
-		strs[i] = Stringer(fs.flags[name], maxLen)
+		strs[i] = Stringer(fs.flags[name], maxLen, hasShort)
 	}
 	return strings.Join(strs, "\n")
 }
@@ -68,6 +74,9 @@ func (fs *FlagSet) addHelpFlag() {
 }
 
 func (fs *FlagSet) AddFlagSet(set *FlagSet) {
+	if set == nil {
+		return
+	}
 	for name, flag := range set.flags {
 		fs.flags[name] = flag
 	}


### PR DESCRIPTION
In certain parts of the command execution, we were walking back up the call tree to find the root command and gathering data along the way.

This walk is redundant given that we are just checking the exact path we just traversed _down_ to the command. So rather than looking for the values back up the call tree, we just store them on the context for access at the relevant leaf of the tree.
