### PR TITLE
Add --version support

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -12,6 +12,7 @@ var rootCmd = &gommand.Command{
 	Name:         "sum",
 	Usage:        "sum [...n]",
 	Description:  "sum all provided numbers",
+	Version:      "1.0.0",
 	ArgValidator: gommand.ArgsEvery(gommand.ArgsMin(1), ints),
 	Run: func(ctx *gommand.Context) error {
 		var total int

--- a/examples/subcommands/main.go
+++ b/examples/subcommands/main.go
@@ -13,6 +13,7 @@ var (
 	rootCmd = &gommand.Command{
 		Name:         "math",
 		Usage:        "a collection of math commands",
+		Version:      "1.0.0",
 		SilenceError: true,
 		PersistentFlagSet: flags.NewFlagSet().AddFlags(
 			flags.StringFlag("host", "", "host address"),


### PR DESCRIPTION
This adds the `Version` value to the command struct, that will be printed when `--version` is passed to the command, as well as in the new `Version: ` section of the help text

closes #15 