### PR TITLE
feat: show `(required)` in flag helptext

### DIFF
--- a/flags/flag.go
+++ b/flags/flag.go
@@ -51,6 +51,10 @@ func Stringer(flag Flag, nameLen int, hasShort bool) string {
 	sb.WriteString(strings.Repeat(" ", nameLen-len(flag.Name())))
 	sb.WriteString("  ")
 	sb.WriteString(flag.Usage())
+	if flag.IsRequired() {
+		sb.WriteString(" ")
+		sb.WriteString("(required)")
+	}
 	return sb.String()
 }
 

--- a/flags/flagset.go
+++ b/flags/flagset.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"errors"
+	"maps"
 	"sort"
 	"strings"
 )
@@ -86,12 +87,10 @@ func (fs *FlagSet) AddFlagSet(set *FlagSet) *FlagSet {
 	if set == nil {
 		return fs
 	}
-	for name, flag := range set.flags {
-		fs.flags[name] = flag
-	}
-	for short, flag := range set.shortFlags {
-		fs.shortFlags[short] = flag
-	}
+
+	maps.Copy(fs.flags, set.flags)
+	maps.Copy(fs.shortFlags, set.shortFlags)
+
 	return fs
 }
 


### PR DESCRIPTION
# Summary

when flags are `.Required()` they will no show up as such in the help text

ie:
```
Usage:
  items

Flags:
  -h, --help     show this help message
      --list-id  ID of list to return items for (required)
```

Closes #29
