### PR TITLE
required flag errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -15,18 +15,23 @@ type Context struct {
 	deferPost    bool
 	silenceHelp  bool
 	silenceError bool
+	depth        int
 
-	persistentFlags *flags.FlagSet
+	persistentFlagSets []*flags.FlagSet
 
 	flagGetter *flags.FlagGetter
 }
 
 func (c *Context) addPersistentFlags(fs *flags.FlagSet) {
-	if c.persistentFlags == nil {
-		c.persistentFlags = fs
-	} else {
-		c.persistentFlags.AddFlagSet(fs)
+	c.persistentFlagSets = append(c.persistentFlagSets, fs)
+}
+
+func (c *Context) persistentFlags() *flags.FlagSet {
+	fs := flags.NewFlagSet()
+	for _, pfs := range c.persistentFlagSets {
+		fs.AddFlagSet(pfs)
 	}
+	return fs
 }
 
 func (c *Context) Args() []string {

--- a/examples/flags/main.go
+++ b/examples/flags/main.go
@@ -8,51 +8,49 @@ import (
 	"github.com/jimmykodes/gommand/flags"
 )
 
-var (
-	rootCmd = &gommand.Command{
-		Name: "root",
-		FlagSet: flags.NewFlagSet().AddFlags(
-			flags.IntFlag("num", 10, "a number"),
-			flags.BoolFlagS("dry-run", 'd', false, "dry run"),
-			flags.BoolFlagS("insensitive", 'i', false, "case-insensitive"),
-			flags.StringSliceFlagS("strings", 's', []string{"test", "taco"}, "some strings"),
-			flags.StringFlag("required", "", "a required string").Required(),
-		),
-		PersistentFlagSet: flags.NewFlagSet().AddFlags(
-			flags.IntFlag("mult", 100, "something"),
-		),
-		ArgValidator: gommand.ArgsAny(),
-		Run: func(ctx *gommand.Context) error {
-			fmt.Println("args", ctx.Args())
-			n := ctx.Flags().Int("num")
-			d, err := ctx.Flags().LookupBool("dry-run")
-			if err != nil {
-				return err
-			}
-			i, err := ctx.Flags().LookupBool("insensitive")
-			if err != nil {
-				return err
-			}
-			if !ctx.Flags().Flag("insensitive").IsSet() {
-				fmt.Println("insensitive used default value")
-			}
-			s, err := ctx.Flags().LookupStringSlice("strings")
-			if err != nil {
-				return err
-			}
-			required, err := ctx.Flags().LookupString("required")
-			if err != nil {
-				return err
-			}
-			fmt.Println("num", n)
-			fmt.Println("dry run", d)
-			fmt.Println("insensitive", i)
-			fmt.Println("strings", s)
-			fmt.Println("required", required)
-			return nil
-		},
-	}
-)
+var rootCmd = &gommand.Command{
+	Name: "root",
+	FlagSet: flags.NewFlagSet().AddFlags(
+		flags.IntFlag("num", 10, "a number"),
+		flags.BoolFlagS("dry-run", 'd', false, "dry run"),
+		flags.BoolFlagS("insensitive", 'i', false, "case-insensitive"),
+		flags.StringSliceFlagS("strings", 's', []string{"test", "taco"}, "some strings"),
+		flags.StringFlag("required", "", "a required string").Required(),
+	),
+	PersistentFlagSet: flags.NewFlagSet().AddFlags(
+		flags.IntFlag("mult", 100, "something"),
+	),
+	ArgValidator: gommand.ArgsAny(),
+	Run: func(ctx *gommand.Context) error {
+		fmt.Println("args", ctx.Args())
+		n := ctx.Flags().Int("num")
+		d, err := ctx.Flags().LookupBool("dry-run")
+		if err != nil {
+			return err
+		}
+		i, err := ctx.Flags().LookupBool("insensitive")
+		if err != nil {
+			return err
+		}
+		if !ctx.Flags().Flag("insensitive").IsSet() {
+			fmt.Println("insensitive used default value")
+		}
+		s, err := ctx.Flags().LookupStringSlice("strings")
+		if err != nil {
+			return err
+		}
+		required, err := ctx.Flags().LookupString("required")
+		if err != nil {
+			return err
+		}
+		fmt.Println("num", n)
+		fmt.Println("dry run", d)
+		fmt.Println("insensitive", i)
+		fmt.Println("strings", s)
+		fmt.Println("required", required)
+		return nil
+	},
+}
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {

--- a/examples/flags/main.go
+++ b/examples/flags/main.go
@@ -11,11 +11,11 @@ import (
 var rootCmd = &gommand.Command{
 	Name: "root",
 	FlagSet: flags.NewFlagSet().AddFlags(
-		flags.IntFlag("num", 10, "a number"),
+		flags.IntFlag("num", 10, "a number").Required(),
 		flags.BoolFlagS("dry-run", 'd', false, "dry run"),
 		flags.BoolFlagS("insensitive", 'i', false, "case-insensitive"),
 		flags.StringSliceFlagS("strings", 's', []string{"test", "taco"}, "some strings"),
-		flags.StringFlag("required", "", "a required string").Required(),
+		flags.StringFlag("required", "", "a required string").AddSources(flags.Environ).Required(),
 	),
 	PersistentFlagSet: flags.NewFlagSet().AddFlags(
 		flags.IntFlag("mult", 100, "something"),

--- a/examples/valuer/cmd/server/run/run.go
+++ b/examples/valuer/cmd/server/run/run.go
@@ -16,7 +16,7 @@ func Cmd(config *conf.Config) *gommand.Command {
 		FlagSet: flags.NewFlagSet().
 			AddSource(flags.ValuerFunc(config.SubPath("server"))).
 			AddFlags(
-				flags.StringFlag("addr", ":8080", "server address"),
+				flags.StringFlag("addr", "", "server address").Required(),
 			),
 		Run: func(ctx *gommand.Context) error {
 			mux := http.NewServeMux()

--- a/flags/flag.go
+++ b/flags/flag.go
@@ -58,6 +58,18 @@ func Stringer(flag Flag, nameLen int, hasShort bool) string {
 	return sb.String()
 }
 
+func SetFromSources(f Flag) error {
+	for _, source := range f.Sources() {
+		if val, ok := source.Value(f.Name()); ok {
+			if err := f.Set(val); err != nil {
+				return err
+			}
+			break
+		}
+	}
+	return nil
+}
+
 type baseFlag struct {
 	name    string
 	short   rune

--- a/flags/flag_getter.go
+++ b/flags/flag_getter.go
@@ -1,5 +1,7 @@
 package flags
 
+import "iter"
+
 func NewFlagGetter(fs *FlagSet) *FlagGetter {
 	return &FlagGetter{fs: fs}
 }
@@ -10,4 +12,14 @@ type FlagGetter struct {
 
 func (g FlagGetter) Flag(name string) Flag {
 	return g.fs.FromName(name)
+}
+
+func (g FlagGetter) All() iter.Seq2[string, Flag] {
+	return func(yield func(string, Flag) bool) {
+		for k, v := range g.fs.flags {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
 }

--- a/flags/flagset.go
+++ b/flags/flagset.go
@@ -133,18 +133,13 @@ func (fs *FlagSet) flag(name string, t FlagType) (Flag, error) {
 	}
 
 	if !f.IsSet() {
-		for _, source := range f.Sources() {
-			if val, ok := source.Value(name); ok {
-				if err := f.Set(val); err != nil {
-					return nil, err
-				}
-				break
-			}
+		if err := SetFromSources(f); err != nil {
+			return nil, err
 		}
 	}
 
 	if !f.IsSet() && f.IsRequired() {
-		// was not set by the command line _or_ the environment
+		// was not set by the command line or any configured source
 		return nil, ErrMissingRequiredFlag{Flag: f}
 	}
 


### PR DESCRIPTION
# Improve required flag errors

When a required flag was not supplied, the only way to detect this error was to use the `Lookup<Type>` function and check the error.
This was unintuitive and so required flags are now checked before run functions are called.
These flags are checked at each execution level so that prerun functions that populate flag sources can still run before validating the next level's flags. 

An example being something like `server run` where the `server` command reads a .json file that has configs like `server.addr = :8080` and the `run` command's `--addr` flag reads from this config file. If we checked all flags before executing any prerun functions, the addr's requirement wouldn't be fulfilled, as the flag's source wouldn't be able to set the value.
By validating at each level, the `server` function's persistent pre run can populate the source and then the `run` flag can _actually_ check to see if it was fulfilled.
This changes the fact that previously all flags were lazy loaded from sources other than the cli. All flags that are _not_ required are still lazy loaded from sources, but required flags must be evaluated to know if they are set.


