### PR TITLE
feat: add Arg(idx int) function

### DIFF
--- a/context.go
+++ b/context.go
@@ -38,6 +38,15 @@ func (c *Context) Args() []string {
 	return c.args
 }
 
+// Arg will return the command line argument at the given index
+// Returns an empty string if idx is out of range
+func (c *Context) Arg(idx int) string {
+	if idx < len(c.args) {
+		return c.args[idx]
+	}
+	return ""
+}
+
 func (c *Context) Flags() *flags.FlagGetter {
 	return c.flagGetter
 }


### PR DESCRIPTION
# Summary

This adds the `Arg(idx int) string` function on `gommand.Context` such that an arg can be looked up
by index. If the index is out of range, an empty string is returned.
